### PR TITLE
Support python2 builds for RHEL7/8

### DIFF
--- a/acitoolkit/rpm/acitoolkit.spec.in
+++ b/acitoolkit/rpm/acitoolkit.spec.in
@@ -9,10 +9,10 @@ License:  Apache 2.0
 URL:      https://github.com/datacenter/acitoolkit
 Source:   %{name}-%{version}.tar.gz
 BuildArch:     noarch
-BuildRequires: python-setuptools
-Requires:      python-requests
+BuildRequires: python2-setuptools
+Requires:      python2-requests
 Requires:      python-websocket-client
-Requires:      python-tabulate
+Requires:      python2-tabulate
 
 %description
 The ACI Toolkit is a set of python libraries that allow basic configuration of the Cisco APIC controller

--- a/acitoolkit/rpm/build-rpm.sh
+++ b/acitoolkit/rpm/build-rpm.sh
@@ -12,9 +12,9 @@ if [ -z $SPEC_FILE_IN ]; then
 fi
 BUILD_DIR=${BUILD_DIR:-`pwd`/rpmbuild}
 mkdir -p $BUILD_DIR/BUILD $BUILD_DIR/SOURCES $BUILD_DIR/SPECS $BUILD_DIR/RPMS $BUILD_DIR/SRPMS
-NAME=`python setup.py --name`
+NAME=`python2 setup.py --name`
 RELEASE=${RELEASE:-1}
-VERSION_PY=`python setup.py --version`
+VERSION_PY=`python2 setup.py --version`
 VERSION=`git describe --tags | tr -d v | cut -d'-' -f1`
 SPEC_FILE=${SPEC_FILE_IN/.in/}
 SPEC_FILE=${SPEC_FILE/rpm\//}
@@ -22,6 +22,6 @@ sed -e "s/@VERSION@/$VERSION/" \
     -e "s/@VERSION_PY@/$VERSION_PY/" \
     -e "s/@RELEASE@/$RELEASE/" \
     $SPEC_FILE_IN > $BUILD_DIR/SPECS/$SPEC_FILE
-python setup.py sdist --dist-dir $BUILD_DIR/SOURCES
+python2 setup.py sdist --dist-dir $BUILD_DIR/SOURCES
 mv $BUILD_DIR/SOURCES/$NAME-$VERSION_PY.tar.gz $BUILD_DIR/SOURCES/$NAME-$VERSION.tar.gz
 rpmbuild --clean -ba --define "_topdir $BUILD_DIR" $BUILD_DIR/SPECS/$SPEC_FILE


### PR DESCRIPTION
Update package names to support python2 packages for both RHEL7
and RHEL8.