### PR TITLE
Fix RHEL8 python2 builds

### DIFF
--- a/acitoolkit/rpm/acitoolkit.spec.in
+++ b/acitoolkit/rpm/acitoolkit.spec.in
@@ -21,17 +21,17 @@ The ACI Toolkit is a set of python libraries that allow basic configuration of t
 %setup -qn %{name}-%{version_py}
 
 %build
-%{__python} setup.py build
+%{__python2} setup.py build
 
 %install
-%{__python} setup.py install -O1 --skip-build --root %{buildroot}
+%{__python2} setup.py install -O1 --skip-build --root %{buildroot}
 
 %clean
 rm -rf %{buildroot}
 
 %files
-%{python_sitelib}/acitoolkit/
-%{python_sitelib}/acitoolkit*.egg-info
+%{python2_sitelib}/acitoolkit/
+%{python2_sitelib}/acitoolkit*.egg-info
 
 %changelog
 * Thu Jul 28 2016 Amit Bose <bose@noironetworks.com> 0.3.2-1


### PR DESCRIPTION
The spec file should use python2 instead of python for variables
in the spec file.