### PR TITLE
Support RHEL9 builds

### DIFF
--- a/noiro-openvswitch/noiro-openvswitch.patch
+++ b/noiro-openvswitch/noiro-openvswitch.patch
@@ -123,3 +123,15 @@ index d6ab517..4f57201 100644
  
  noinst_PROGRAMS += tests/test-stream
  tests_test_stream_SOURCES = tests/test-stream.c
+diff --git a/ovsdb/ovsdb-idlc.in b/ovsdb/ovsdb-idlc.in
+index 40fef39ed..22d0a4e22 100755
+--- a/ovsdb/ovsdb-idlc.in
++++ b/ovsdb/ovsdb-idlc.in
+@@ -176,7 +176,7 @@ def replace_cplusplus_keyword(schema):
+                 'wchar_t', 'while', 'xor', 'xor_eq'}
+
+     for tableName, table in schema.tables.items():
+-        for columnName in table.columns:
++        for columnName in list(table.columns):
+             if columnName in keywords:
+                 table.columns[columnName + '_'] = table.columns.pop(columnName)


### PR DESCRIPTION
RHEL9 builds need to support python3 only, so the OVS 2.12 branch must be fixed to support python3.